### PR TITLE
Template on hardware type (i.e., matchbin config)

### DIFF
--- a/source/Cell.h
+++ b/source/Cell.h
@@ -6,6 +6,7 @@
 #include "Sequence.h"
 #include "Trait.h"
 
+template <typename CH>
 struct Cell{
 private:
   const Config & cfg;
@@ -13,10 +14,10 @@ private:
 public:
   Cell(
     const Config & cfg_,
-    Config::inst_lib_t& il,
-    Config::event_lib_t& el,
+    typename CH::inst_lib_t& il,
+    typename CH::event_lib_t& el,
     emp::Random& random,
-    Config::mutator_t& mut
+    typename CH::mutator_t& mut
   ) : cfg(cfg_)
   , rand(random)
   , hardware(il, el, &random)
@@ -42,7 +43,7 @@ public:
     std::cout <<"\n\n";
   }
 
-  void SetProgram(Config::program_t program){
+  void SetProgram(typename CH::program_t program){
     hardware.SetProgram(program);
   }
 
@@ -80,8 +81,8 @@ public:
 
 public:
     emp::Random &rand;
-    Config::hardware_t hardware;
-    Config::mutator_t mutator;
+    typename CH::hardware_t hardware;
+    typename CH::mutator_t mutator;
 
 private:
   void ConfigureHardware(){
@@ -90,7 +91,9 @@ private:
     hardware.SetMaxCallDepth(cfg.HW_MAX_CALL_DEPTH());
 
     // Create a way for the hardware to print our traits.
-    auto trait_printer = [](std::ostream& os, Config::TRAIT_TYPE trait){
+    auto trait_printer = [](
+      std::ostream& os, typename CH::TRAIT_TYPE trait
+    ){
       os << "[SF: " << trait.seq->P()
          << " -- G: " << trait.guess << "]"
          << std::endl;

--- a/source/Config.h
+++ b/source/Config.h
@@ -13,25 +13,6 @@ class Config : public ConfigBase {
 
     Config(){};
 
-    static constexpr size_t TAG_WIDTH = 16;
-
-    using TRAIT_TYPE = Trait;
-    using hardware_t = emp::EventDrivenGP_AW<
-      TAG_WIDTH
-      , TRAIT_TYPE
-      , emp::MatchBin<
-        size_t
-        , emp::HammingMetric<16>
-        , emp::RankedSelector<std::ratio<24,16>>
-        >
-      >;
-    using inst_lib_t = emp::InstLib<hardware_t>;
-    using inst_t = hardware_t::Instruction;
-    using event_lib_t = emp::EventLib<hardware_t>;
-    using state_t = hardware_t::State;
-    using program_t = hardware_t::Program;
-    using mutator_t = emp::SignalGPMutator<TAG_WIDTH, TRAIT_TYPE>;
-
     // TODO allow a variable number of streaky factors's
     double SEQS(const size_t idx) const {
       if (idx == 0) return SEQ_A();

--- a/source/ConfigHardware.h
+++ b/source/ConfigHardware.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "base/vector.h"
+#include "base/Ptr.h"
+#include "hardware/EventDrivenGP.h"
+#include "hardware/signalgp_utils.h"
+#include "ConfigBase.h"
+#include "Trait.h"
+
+template<typename Metric, typename Selector>
+class ConfigHardware {
+
+  public:
+
+    static constexpr size_t TAG_WIDTH = 16;
+
+    using TRAIT_TYPE = Trait;
+    using hardware_t = emp::EventDrivenGP_AW<
+      TAG_WIDTH
+      , TRAIT_TYPE
+      , emp::MatchBin<
+        size_t
+        , Metric
+        , Selector
+        >
+      >;
+    using inst_lib_t = emp::InstLib<hardware_t>;
+    using inst_t = typename hardware_t::Instruction;
+    using event_lib_t = emp::EventLib<hardware_t>;
+    using state_t = typename hardware_t::State;
+    using program_t = typename hardware_t::Program;
+    using mutator_t = emp::SignalGPMutator<TAG_WIDTH, TRAIT_TYPE>;
+
+};

--- a/source/InstructionLibrary.h
+++ b/source/InstructionLibrary.h
@@ -5,12 +5,16 @@
 #include "Config.h"
 #include "Sequence.h"
 
+template <typename CH>
 class InstructionLibrary{
   public:
   InstructionLibrary()=default;
 
-  Config::inst_lib_t& CreateInstLib(const Config & cfg, emp::Random& random){
-    inst_lib = Config::inst_lib_t();
+  typename CH::inst_lib_t& CreateInstLib(
+    const Config & cfg,
+    emp::Random& random
+  ){
+    inst_lib = typename CH::inst_lib_t();
     InitializeDefault();
     InitializeCustom(cfg, random);
     return inst_lib;
@@ -18,41 +22,44 @@ class InstructionLibrary{
 
   private:
     void InitializeDefault(){
-    inst_lib.AddInst("Inc", Config::hardware_t::Inst_Inc, 1, "Increment value in local memory Arg1");
-    inst_lib.AddInst("Dec", Config::hardware_t::Inst_Dec, 1, "Decrement value in local memory Arg1");
-    inst_lib.AddInst("Not", Config::hardware_t::Inst_Not, 1, "Logically toggle value in local memory Arg1");
-    inst_lib.AddInst("Add", Config::hardware_t::Inst_Add, 3, "Local memory: Arg3 = Arg1 + Arg2");
-    inst_lib.AddInst("Sub", Config::hardware_t::Inst_Sub, 3, "Local memory: Arg3 = Arg1 - Arg2");
-    inst_lib.AddInst("Mult", Config::hardware_t::Inst_Mult, 3, "Local memory: Arg3 = Arg1 * Arg2");
-    inst_lib.AddInst("Div", Config::hardware_t::Inst_Div, 3, "Local memory: Arg3 = Arg1 / Arg2");
-    inst_lib.AddInst("Mod", Config::hardware_t::Inst_Mod, 3, "Local memory: Arg3 = Arg1 % Arg2");
-    inst_lib.AddInst("TestEqu", Config::hardware_t::Inst_TestEqu, 3, "Local memory: Arg3 = (Arg1 == Arg2)");
-    inst_lib.AddInst("TestNEqu", Config::hardware_t::Inst_TestNEqu, 3, "Local memory: Arg3 = (Arg1 != Arg2)");
-    inst_lib.AddInst("TestLess", Config::hardware_t::Inst_TestLess, 3, "Local memory: Arg3 = (Arg1 < Arg2)");
-    inst_lib.AddInst("If", Config::hardware_t::Inst_If, 1, "Local memory: If Arg1 != 0, proceed; else, skip block.", emp::ScopeType::BASIC, 0, {"block_def"});
-    inst_lib.AddInst("While", Config::hardware_t::Inst_While, 1, "Local memory: If Arg1 != 0, loop; else, skip block.", emp::ScopeType::BASIC, 0, {"block_def"});
-    inst_lib.AddInst("Countdown", Config::hardware_t::Inst_Countdown, 1, "Local memory: Countdown Arg1 to zero.", emp::ScopeType::BASIC, 0, {"block_def"});
-    inst_lib.AddInst("Close", Config::hardware_t::Inst_Close, 0, "Close current block if there is a block to close.", emp::ScopeType::BASIC, 0, {"block_close"});
-    inst_lib.AddInst("Break", Config::hardware_t::Inst_Break, 0, "Break out of current block.");
-    inst_lib.AddInst("Call", Config::hardware_t::Inst_Call, 0, "Call function that best matches call affinity.", emp::ScopeType::BASIC, 0, {"affinity"});
-    inst_lib.AddInst("Return", Config::hardware_t::Inst_Return, 0, "Return from current function if possible.");
-    inst_lib.AddInst("SetMem", Config::hardware_t::Inst_SetMem, 2, "Local memory: Arg1 = numerical value of Arg2");
-    inst_lib.AddInst("CopyMem", Config::hardware_t::Inst_CopyMem, 2, "Local memory: Arg1 = Arg2");
-    inst_lib.AddInst("SwapMem", Config::hardware_t::Inst_SwapMem, 2, "Local memory: Swap values of Arg1 and Arg2.");
-    inst_lib.AddInst("Input", Config::hardware_t::Inst_Input, 2, "Input memory Arg1 => Local memory Arg2.");
-    inst_lib.AddInst("Output", Config::hardware_t::Inst_Output, 2, "Local memory Arg1 => Output memory Arg2.");
-    inst_lib.AddInst("Commit", Config::hardware_t::Inst_Commit, 2, "Local memory Arg1 => Shared memory Arg2.");
-    inst_lib.AddInst("Pull", Config::hardware_t::Inst_Pull, 2, "Shared memory Arg1 => Shared memory Arg2.");
-    inst_lib.AddInst("Fork", Config::hardware_t::Inst_Fork, 0, "Fork a new thread, using tag-based referencing to determine which function to call on the new thread.", emp::ScopeType::BASIC, 0, {"affinity"});
-    inst_lib.AddInst("Terminate", Config::hardware_t::Inst_Terminate, 0, "Terminate current thread.");
-    inst_lib.AddInst("Nop", Config::hardware_t::Inst_Nop, 0, "No operation.");
+    inst_lib.AddInst("Inc", CH::hardware_t::Inst_Inc, 1, "Increment value in local memory Arg1");
+    inst_lib.AddInst("Dec", CH::hardware_t::Inst_Dec, 1, "Decrement value in local memory Arg1");
+    inst_lib.AddInst("Not", CH::hardware_t::Inst_Not, 1, "Logically toggle value in local memory Arg1");
+    inst_lib.AddInst("Add", CH::hardware_t::Inst_Add, 3, "Local memory: Arg3 = Arg1 + Arg2");
+    inst_lib.AddInst("Sub", CH::hardware_t::Inst_Sub, 3, "Local memory: Arg3 = Arg1 - Arg2");
+    inst_lib.AddInst("Mult", CH::hardware_t::Inst_Mult, 3, "Local memory: Arg3 = Arg1 * Arg2");
+    inst_lib.AddInst("Div", CH::hardware_t::Inst_Div, 3, "Local memory: Arg3 = Arg1 / Arg2");
+    inst_lib.AddInst("Mod", CH::hardware_t::Inst_Mod, 3, "Local memory: Arg3 = Arg1 % Arg2");
+    inst_lib.AddInst("TestEqu", CH::hardware_t::Inst_TestEqu, 3, "Local memory: Arg3 = (Arg1 == Arg2)");
+    inst_lib.AddInst("TestNEqu", CH::hardware_t::Inst_TestNEqu, 3, "Local memory: Arg3 = (Arg1 != Arg2)");
+    inst_lib.AddInst("TestLess", CH::hardware_t::Inst_TestLess, 3, "Local memory: Arg3 = (Arg1 < Arg2)");
+    inst_lib.AddInst("If", CH::hardware_t::Inst_If, 1, "Local memory: If Arg1 != 0, proceed; else, skip block.", emp::ScopeType::BASIC, 0, {"block_def"});
+    inst_lib.AddInst("While", CH::hardware_t::Inst_While, 1, "Local memory: If Arg1 != 0, loop; else, skip block.", emp::ScopeType::BASIC, 0, {"block_def"});
+    inst_lib.AddInst("Countdown", CH::hardware_t::Inst_Countdown, 1, "Local memory: Countdown Arg1 to zero.", emp::ScopeType::BASIC, 0, {"block_def"});
+    inst_lib.AddInst("Close", CH::hardware_t::Inst_Close, 0, "Close current block if there is a block to close.", emp::ScopeType::BASIC, 0, {"block_close"});
+    inst_lib.AddInst("Break", CH::hardware_t::Inst_Break, 0, "Break out of current block.");
+    inst_lib.AddInst("Call", CH::hardware_t::Inst_Call, 0, "Call function that best matches call affinity.", emp::ScopeType::BASIC, 0, {"affinity"});
+    inst_lib.AddInst("Return", CH::hardware_t::Inst_Return, 0, "Return from current function if possible.");
+    inst_lib.AddInst("SetMem", CH::hardware_t::Inst_SetMem, 2, "Local memory: Arg1 = numerical value of Arg2");
+    inst_lib.AddInst("CopyMem", CH::hardware_t::Inst_CopyMem, 2, "Local memory: Arg1 = Arg2");
+    inst_lib.AddInst("SwapMem", CH::hardware_t::Inst_SwapMem, 2, "Local memory: Swap values of Arg1 and Arg2.");
+    inst_lib.AddInst("Input", CH::hardware_t::Inst_Input, 2, "Input memory Arg1 => Local memory Arg2.");
+    inst_lib.AddInst("Output", CH::hardware_t::Inst_Output, 2, "Local memory Arg1 => Output memory Arg2.");
+    inst_lib.AddInst("Commit", CH::hardware_t::Inst_Commit, 2, "Local memory Arg1 => Shared memory Arg2.");
+    inst_lib.AddInst("Pull", CH::hardware_t::Inst_Pull, 2, "Shared memory Arg1 => Shared memory Arg2.");
+    inst_lib.AddInst("Fork", CH::hardware_t::Inst_Fork, 0, "Fork a new thread, using tag-based referencing to determine which function to call on the new thread.", emp::ScopeType::BASIC, 0, {"affinity"});
+    inst_lib.AddInst("Terminate", CH::hardware_t::Inst_Terminate, 0, "Terminate current thread.");
+    inst_lib.AddInst("Nop", CH::hardware_t::Inst_Nop, 0, "No operation.");
     }
 
     void InitializeCustom(const Config & cfg, emp::Random& random){
     inst_lib.AddInst(
      "Sense",
-      [&](Config::hardware_t & hw, const Config::inst_t & inst) {
-        Config::state_t& state = hw.GetCurState();
+      [&](
+        typename CH::hardware_t & hw,
+        const typename CH::inst_t & inst
+      ) {
+        typename CH::state_t& state = hw.GetCurState();
         const int cur = hw.GetTrait().seq->Get(hw.GetTrait().senseCount++);
         state.SetLocal(inst.args[0], cur);
       },
@@ -64,7 +71,10 @@ class InstructionLibrary{
 
       inst_lib.AddInst(
         emp::to_string("GS_", idx),
-        [idx](Config::hardware_t & hw, const Config::inst_t & inst){
+        [idx](
+          typename CH::hardware_t & hw,
+          const typename CH::inst_t & inst
+        ){
           hw.GetTrait().guess = idx;
           hw.GetTrait().guessCount[idx]+=1;
         },
@@ -74,9 +84,9 @@ class InstructionLibrary{
 
     }
 
-    //inst_lib.AddInst("Debug",[](Config::hardware_t& hw, const Config::inst_t& inst){Config::state_t& state = hw.GetCurState(); std::cout << state.GetLocal(inst.args[0])<<std::endl;},1,"debug");
+    //inst_lib.AddInst("Debug",[](CH::hardware_t& hw, const CH::inst_t& inst){CH::state_t& state = hw.GetCurState(); std::cout << state.GetLocal(inst.args[0])<<std::endl;},1,"debug");
     }
   private:
-    Config::inst_lib_t inst_lib;
+    typename CH::inst_lib_t inst_lib;
 
 };

--- a/source/StreakyWorld.h
+++ b/source/StreakyWorld.h
@@ -8,16 +8,17 @@
 #include "Cell.h"
 #include "Config.h"
 
-
-class StreakyWorld: public emp::World<Cell>{
+template<typename CH>
+class StreakyWorld: public emp::World<Cell<CH>> {
   public:
+
     StreakyWorld(const Config & cfg);
     void Restart();
     void Tick();
     void PrintCurrentState();
     void CreatePopulation(const unsigned int SAMPLES);
     void Start();
-    double GetFitness(Cell& cell);
+    double GetFitness(Cell<CH>& cell);
 
   private:
     void ConfigureHardware();
@@ -27,9 +28,9 @@ class StreakyWorld: public emp::World<Cell>{
   private:
     const Config & cfg;
     emp::Random random;
-    Config::inst_lib_t inst_lib;
-    Config::event_lib_t event_lib;
-    Config::mutator_t mutator;
+    typename CH::inst_lib_t inst_lib;
+    typename CH::event_lib_t event_lib;
+    typename CH::mutator_t mutator;
 
     emp::vector<emp::DataMonitor<double>> guessMonitors;
     emp::DataMonitor<double> senseMonitor;

--- a/source/native/streaky.cc
+++ b/source/native/streaky.cc
@@ -11,6 +11,7 @@
 #include "config/ArgManager.h"
 
 #include "../Config.h"
+#include "../ConfigHardware.h"
 #include "../StreakyWorld.cc"
 #include "../Trait.cc"
 
@@ -60,23 +61,45 @@ int main(int argc, char* argv[])
 
   while (res->size()) {
 
-    if (res->back() == "evolve") {
+    if (res->back() == "evolve-ranked") {
 
       std::cout << "running mode: " << res->back() << std::endl;
-      StreakyWorld streakyWorld(cfg);
-      streakyWorld.CreatePopulation(cfg.POP_SIZE());
-      streakyWorld.Start();
+      StreakyWorld<
+        ConfigHardware<
+          emp::HammingMetric<16>,
+          emp::RankedSelector<std::ratio<24,16>>
+        >
+      > rankedWorld(cfg);
+      rankedWorld.CreatePopulation(cfg.POP_SIZE());
+      rankedWorld.Start();
+      std::cout << "DONE." << std::endl;
+
+    } else if (res->back() == "evolve-roulette") {
+
+      std::cout << "running mode: " << res->back() << std::endl;
+      // StreakyWorld<
+      //   ConfigHardware<
+      //     emp::StreakMetric<16>,
+      //     emp::RouletteSelector<>
+      //   >
+      // > rouletteWorld(cfg);
+      // rouletteWorld.CreatePopulation(cfg.POP_SIZE());
+      // rouletteWorld.Start();
       std::cout << "DONE." << std::endl;
 
     } else if (res->back() == "run-program") {
 
       std::cout << "running mode: " << res->back() << std::endl;
       emp::Random random(1);
-      InstructionLibrary il;
-      Config::inst_lib_t& inst_lib = il.CreateInstLib(cfg, random);
-      Config::event_lib_t event_lib;
+      using CH = ConfigHardware<
+        emp::HammingMetric<16>,
+        emp::RankedSelector<std::ratio<24,16>>
+      >;
+      InstructionLibrary<CH> il;
+      CH::inst_lib_t& inst_lib = il.CreateInstLib(cfg, random);
+      CH::event_lib_t event_lib;
 
-      Config::hardware_t hardware(inst_lib, event_lib, &random);
+      CH::hardware_t hardware(inst_lib, event_lib, &random);
       std::ifstream prog (cfg.PROGRAM_FILENAME());
       hardware.GetProgram().Load(prog);
       prog.close();


### PR DESCRIPTION
Something inside of Empirical isn't happy with instantiating mutators and instruction libraries with hardware templated on a streak / roulette matchbin, so I left the new evolve-roulette mode commented out. evolve-ranked mode does run currently, and evolve-roulette should be fine to uncomment once we fix whatever's going on inside Empirical 