### PR TITLE
Add exproulette selector run mode and distqsub request

### DIFF
--- a/request/streaky-evolve-exproulette.distqsub
+++ b/request/streaky-evolve-exproulette.distqsub
@@ -1,0 +1,10 @@
+set email riziknat@msu.edu
+set freq_email Crash
+set description streaky-evolve-roulette
+set mem_request 12
+set walltime 160
+set beacon_priority y
+set config_dir /mnt/scratch/riziknat/streaky-evolve/config
+set dest_dir /mnt/scratch/riziknat/streaky-evolve/data
+
+1001..1020 streaky-evolve-exproulette module purge; module load GCC/8.2.0-2.31.1; timeout 23h ./streaky evolve-roulette -SEED $seed -SEQ_A 0.2 -SEQ_B 0.8 -TREATMENT exproulette || true

--- a/source/native/streaky.cc
+++ b/source/native/streaky.cc
@@ -76,6 +76,19 @@ int main(int argc, char* argv[])
        rouletteWorld.Start();
       std::cout << "DONE." << std::endl;
 
+    } else if (res->back() == "evolve-exproulette") {
+
+      std::cout << "running mode: " << res->back() << std::endl;
+       StreakyWorld<
+         ConfigHardware<
+           emp::StreakMetric<16>,
+           emp::ExpRouletteSelector<>
+         >
+       > rouletteWorld(cfg);
+       rouletteWorld.CreatePopulation(cfg.POP_SIZE());
+       rouletteWorld.Start();
+      std::cout << "DONE." << std::endl;
+
     } else if (res->back() == "run-program") {
 
       std::cout << "running mode: " << res->back() << std::endl;


### PR DESCRIPTION
The ExpRouletteSelector does the same thing as the RouletteSelector, but uses slightly different math so that probability of matching doesn't tail off as abruptly (e.g., it's easier to get two options that have comparable probabilities of being selected). Not sure if this will work any better than regular RouletteSelector, but it should be worth including on future runs to see if anything interesting happens.